### PR TITLE
Update GitHub Actions to use modern release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,12 +185,11 @@ jobs:
         EOF
         
     - name: Create GitHub Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
         tag_name: v${{ steps.bump.outputs.new_version }}
-        release_name: IP Query Tool v${{ steps.bump.outputs.new_version }}
+        name: IP Query Tool v${{ steps.bump.outputs.new_version }}
         body_path: release_notes.md
         draft: false
         prerelease: false
+        generate_release_notes: false


### PR DESCRIPTION
- Replace deprecated actions/create-release@v1 with softprops/action-gh-release@v1
- Workflows already using modern GITHUB_OUTPUT format (no set-output deprecation issues)
- All actions using latest versions (checkout@v4, setup-node@v4)